### PR TITLE
`aws_s3_bucket` errors out with 4.x AWS provider

### DIFF
--- a/sandbox/terraform/versions.tf
+++ b/sandbox/terraform/versions.tf
@@ -1,0 +1,8 @@
+terraform {
+  required_providers {
+    aws = {
+      source  = "hashicorp/aws"
+      version = "~> 3.0"
+    }
+  }
+}


### PR DESCRIPTION
This will prevent issues coming up with the new aws 4.x provider

Or we can bump up the `aws_s3_bucket` resource to use aws 4.x standards for `acl`.

https://github.com/hashicorp/learn-terraform-aft-account-customizations/blob/45df9b82c1a66861f66858e503311ee1b3eca516/sandbox/terraform/s3.tf#L3-L6